### PR TITLE
feat(osdf): implement OSDF map and traffic visualization components

### DIFF
--- a/components/osdf/OsdfKpis.js
+++ b/components/osdf/OsdfKpis.js
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { RiArrowDownLine, RiArrowUpLine, RiDatabase2Line } from '@remixicon/react';
+import { AreaChart, Card } from '@tremor/react';
+import { formatNetworkRate, formatShortNumber } from './formatters';
+
+function useCountUpValue(targetValue, { duration = 700, enabled = true } = {}) {
+  const numericTarget = Number.isFinite(targetValue) ? targetValue : 0;
+  const [animatedValue, setAnimatedValue] = useState(numericTarget);
+  const valueRef = useRef(numericTarget);
+
+  useEffect(() => {
+    if (!enabled) {
+      valueRef.current = numericTarget;
+      setAnimatedValue(numericTarget);
+      return undefined;
+    }
+
+    const startValue = valueRef.current;
+    const delta = numericTarget - startValue;
+    const startTime = performance.now();
+    let frameId = 0;
+
+    const tick = (now) => {
+      const progress = Math.min((now - startTime) / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      const nextValue = startValue + delta * eased;
+      valueRef.current = nextValue;
+      setAnimatedValue(nextValue);
+      if (progress < 1) {
+        frameId = requestAnimationFrame(tick);
+      }
+    };
+
+    frameId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frameId);
+  }, [duration, enabled, numericTarget]);
+
+  return animatedValue;
+}
+
+function KpiValue({ loading, value, accentClassName = 'text-slate-100' }) {
+  if (loading) {
+    return <div className="mt-2 h-9 w-40 animate-pulse rounded-md bg-slate-700/70" />;
+  }
+
+  return (
+    <div className={`mt-1.5 text-[2rem] font-semibold leading-none tracking-tight ${accentClassName}`}>
+      {value}
+    </div>
+  );
+}
+
+function KpiTrend({ loading, chartData, category, color, chartClassName = '' }) {
+  if (loading) {
+    return <div className="mt-2 h-16 w-full animate-pulse rounded-md bg-slate-700/50" />;
+  }
+
+  if (!chartData.length) {
+    return (
+      <div className="mt-3 rounded-md border border-dashed border-slate-700 bg-slate-900/30 p-2 text-center text-xs text-slate-400">
+        No trend data available
+      </div>
+    );
+  }
+
+  return (
+    <div className={chartClassName}>
+      <AreaChart
+        data={chartData}
+        index="time"
+        categories={[category]}
+        colors={[color]}
+        showLegend={false}
+        showYAxis={false}
+        showGridLines={false}
+        showGradient={false}
+        startEndOnly={true}
+        valueFormatter={formatNetworkRate}
+        className="mt-1.5 h-16"
+      />
+    </div>
+  );
+}
+
+function KpiTitle({ icon: Icon, title, iconClassName }) {
+  return (
+    <div className="flex items-center gap-2 text-sm font-medium">
+      <span className={`inline-flex h-5 w-5 items-center justify-center rounded ${iconClassName}`}>
+        <Icon size={14} />
+      </span>
+      <span>{title}</span>
+    </div>
+  );
+}
+
+export default function OsdfKpis({ totalNodes, aggregateTraffic, isLoading }) {
+  const trendData = useMemo(() => {
+    const points = Array.isArray(aggregateTraffic?.timeseries) ? aggregateTraffic.timeseries : [];
+    return points.map((point) => ({
+      time: new Date(point.timestamp).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+      sent: Number(point.upload) || 0,
+      received: Number(point.download) || 0,
+    }));
+  }, [aggregateTraffic?.timeseries]);
+
+  const animatedTotalNodes = useCountUpValue(totalNodes, {
+    duration: 700,
+    enabled: !isLoading,
+  });
+  const animatedSent = useCountUpValue(aggregateTraffic?.upload || 0, {
+    duration: 850,
+    enabled: !isLoading,
+  });
+  const animatedReceived = useCountUpValue(aggregateTraffic?.download || 0, {
+    duration: 850,
+    enabled: !isLoading,
+  });
+
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+      <Card className="!p-4 border border-slate-600/90 bg-slate-800/80 shadow-none ring-0">
+        <KpiTitle
+          icon={RiDatabase2Line}
+          title="Total OSDF Nodes"
+          iconClassName="bg-slate-700 text-slate-200"
+        />
+        <KpiValue loading={isLoading} value={formatShortNumber(Math.round(animatedTotalNodes))} />
+        <p className="mt-2 text-[11px] leading-relaxed text-slate-500">
+          Not all OSDF nodes are part of the{' '}
+          <a
+            href="https://nrp.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-sky-300 underline decoration-sky-500/60 underline-offset-2 hover:text-sky-200"
+          >
+            National Research Platform
+          </a>
+          . Only OSDF nodes that are part of the NRP are measured and visualized here.
+        </p>
+      </Card>
+
+      <Card className="!p-4 border border-emerald-500/45 bg-slate-800/85 shadow-none ring-0">
+        <KpiTitle
+          icon={RiArrowUpLine}
+          title="Data being sent from OSDF nodes"
+          iconClassName="bg-emerald-500/20 text-[#22ff88]"
+        />
+        <KpiValue
+          loading={isLoading}
+          value={formatNetworkRate(animatedSent)}
+          accentClassName="text-[#7dffbc]"
+        />
+        <KpiTrend
+          loading={isLoading}
+          chartData={trendData}
+          category="sent"
+          color="emerald"
+          chartClassName="kpi-trend-sent"
+        />
+      </Card>
+
+      <Card className="!p-4 border border-sky-500/45 bg-slate-800/85 shadow-none ring-0">
+        <KpiTitle
+          icon={RiArrowDownLine}
+          title="Data being received by OSDF nodes"
+          iconClassName="bg-sky-500/20 text-sky-300"
+        />
+        <KpiValue
+          loading={isLoading}
+          value={formatNetworkRate(animatedReceived)}
+          accentClassName="text-sky-200"
+        />
+        <KpiTrend
+          loading={isLoading}
+          chartData={trendData}
+          category="received"
+          color="sky"
+          chartClassName="kpi-trend-received"
+        />
+      </Card>
+    </div>
+  );
+}

--- a/components/osdf/OsdfMap.js
+++ b/components/osdf/OsdfMap.js
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import MapView, {
+  FullscreenControl,
+  Layer,
+  NavigationControl,
+  Popup,
+  Source,
+} from 'react-map-gl';
+import OsdfPopup from './OsdfPopup';
+
+const ENABLE_CLUSTERING = false;
+const SOURCE_ID = 'osdf-node-source';
+const CLUSTER_SOURCE_ID = 'osdf-node-cluster-source';
+const ACTIVE_SOURCE_ID = ENABLE_CLUSTERING ? CLUSTER_SOURCE_ID : SOURCE_ID;
+
+const OUTER_HALO_LAYER_ID = 'osdf-outer-halo-layer';
+const MID_HALO_LAYER_ID = 'osdf-mid-halo-layer';
+const CORE_LAYER_ID = 'osdf-core-layer';
+const CLUSTER_LAYER_ID = 'osdf-cluster-layer';
+const CLUSTER_COUNT_LAYER_ID = 'osdf-cluster-count-layer';
+
+const CLUSTER_MAX_ZOOM = 3;
+const CLUSTER_RADIUS = 40;
+
+const TRAFFIC_NORM_EXPRESSION = ['coalesce', ['get', 'trafficNorm'], 0];
+const HOVER_EXPRESSION = ['case', ['boolean', ['feature-state', 'hover'], false], 1, 0];
+const TRAFFIC_COLOR_EXPRESSION = [
+  'interpolate',
+  ['linear'],
+  TRAFFIC_NORM_EXPRESSION,
+  0,
+  '#ff9f1c',
+  0.55,
+  '#ffd166',
+  1,
+  '#22ff88',
+];
+
+const outerHaloLayer = {
+  id: OUTER_HALO_LAYER_ID,
+  type: 'circle',
+  ...(ENABLE_CLUSTERING ? { filter: ['!', ['has', 'point_count']] } : {}),
+  paint: {
+    'circle-color': TRAFFIC_COLOR_EXPRESSION,
+    'circle-radius': [
+      'interpolate',
+      ['linear'],
+      ['zoom'],
+      1,
+      ['+', 22, ['*', TRAFFIC_NORM_EXPRESSION, 4], ['*', HOVER_EXPRESSION, 1.8]],
+      5,
+      ['+', 25, ['*', TRAFFIC_NORM_EXPRESSION, 5], ['*', HOVER_EXPRESSION, 2.2]],
+    ],
+    'circle-opacity': ['+', 0.06, ['*', TRAFFIC_NORM_EXPRESSION, 0.04], ['*', HOVER_EXPRESSION, 0.05]],
+    'circle-blur': 0.55,
+    'circle-radius-transition': { duration: 140, delay: 0 },
+    'circle-opacity-transition': { duration: 140, delay: 0 },
+  },
+};
+
+const midHaloLayer = {
+  id: MID_HALO_LAYER_ID,
+  type: 'circle',
+  ...(ENABLE_CLUSTERING ? { filter: ['!', ['has', 'point_count']] } : {}),
+  paint: {
+    'circle-color': TRAFFIC_COLOR_EXPRESSION,
+    'circle-radius': [
+      'interpolate',
+      ['linear'],
+      ['zoom'],
+      1,
+      ['+', 12, ['*', TRAFFIC_NORM_EXPRESSION, 4], ['*', HOVER_EXPRESSION, 1.1]],
+      5,
+      ['+', 14, ['*', TRAFFIC_NORM_EXPRESSION, 4.5], ['*', HOVER_EXPRESSION, 1.4]],
+    ],
+    'circle-opacity': ['+', 0.15, ['*', TRAFFIC_NORM_EXPRESSION, 0.1], ['*', HOVER_EXPRESSION, 0.08]],
+    'circle-blur': 0.2,
+    'circle-radius-transition': { duration: 140, delay: 0 },
+    'circle-opacity-transition': { duration: 140, delay: 0 },
+  },
+};
+
+const coreLayer = {
+  id: CORE_LAYER_ID,
+  type: 'circle',
+  ...(ENABLE_CLUSTERING ? { filter: ['!', ['has', 'point_count']] } : {}),
+  paint: {
+    'circle-color': TRAFFIC_COLOR_EXPRESSION,
+    'circle-radius': [
+      'interpolate',
+      ['linear'],
+      ['zoom'],
+      1,
+      ['+', 5, ['*', TRAFFIC_NORM_EXPRESSION, 5], ['*', HOVER_EXPRESSION, 1.2]],
+      5,
+      ['+', 6, ['*', TRAFFIC_NORM_EXPRESSION, 5.5], ['*', HOVER_EXPRESSION, 1.4]],
+    ],
+    'circle-opacity': ['+', 0.92, ['*', HOVER_EXPRESSION, 0.08]],
+    'circle-stroke-color': '#0b1220',
+    'circle-stroke-width': ['+', 1.1, ['*', HOVER_EXPRESSION, 0.55]],
+    'circle-radius-transition': { duration: 140, delay: 0 },
+    'circle-opacity-transition': { duration: 140, delay: 0 },
+  },
+};
+
+const clusterLayer = {
+  id: CLUSTER_LAYER_ID,
+  type: 'circle',
+  filter: ['has', 'point_count'],
+  paint: {
+    'circle-color': '#0f172a',
+    'circle-radius': ['step', ['get', 'point_count'], 15, 16, 18, 40, 22],
+    'circle-opacity': 0.9,
+    'circle-stroke-color': '#22ff88',
+    'circle-stroke-width': 1.2,
+  },
+};
+
+const clusterCountLayer = {
+  id: CLUSTER_COUNT_LAYER_ID,
+  type: 'symbol',
+  filter: ['has', 'point_count'],
+  layout: {
+    'text-field': ['get', 'point_count_abbreviated'],
+    'text-size': 11,
+    'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+  },
+  paint: {
+    'text-color': '#bbf7d0',
+  },
+};
+
+function enrichNodeTraffic(nodes) {
+  const totals = nodes.map((node) => (Number(node.upload) || 0) + (Number(node.download) || 0));
+  const min = totals.length > 0 ? Math.min(...totals) : 0;
+  const max = totals.length > 0 ? Math.max(...totals) : 0;
+  const range = max - min;
+
+  return nodes.map((node) => {
+    const totalTraffic = (Number(node.upload) || 0) + (Number(node.download) || 0);
+    const trafficNorm = range > 0 ? (totalTraffic - min) / range : totalTraffic > 0 ? 1 : 0;
+    return {
+      ...node,
+      totalTraffic,
+      trafficNorm,
+    };
+  });
+}
+
+function softenCompetingStyleLayers(mapInstance) {
+  const style = mapInstance.getStyle();
+  const layers = style?.layers || [];
+
+  for (const layer of layers) {
+    if (layer.id.startsWith('osdf-')) continue;
+    try {
+      if (layer.type === 'background') {
+        mapInstance.setPaintProperty(layer.id, 'background-color', '#060914');
+      }
+
+      if (layer.type === 'circle' && /(dot|dots|mesh|grid|point|globe|world)/i.test(layer.id)) {
+        const currentOpacity = mapInstance.getPaintProperty(layer.id, 'circle-opacity');
+        if (typeof currentOpacity === 'number') {
+          mapInstance.setPaintProperty(layer.id, 'circle-opacity', Math.max(0.05, currentOpacity * 0.72));
+        } else if (typeof currentOpacity === 'undefined') {
+          mapInstance.setPaintProperty(layer.id, 'circle-opacity', 0.3);
+        }
+      }
+
+      if (layer.type === 'fill' && /land/i.test(layer.id)) {
+        const currentFillOpacity = mapInstance.getPaintProperty(layer.id, 'fill-opacity');
+        if (typeof currentFillOpacity === 'number' && currentFillOpacity > 0.75) {
+          mapInstance.setPaintProperty(layer.id, 'fill-opacity', 0.75);
+        }
+      }
+    } catch (error) {
+      // Ignore style-layer-specific paint operations that are unsupported.
+    }
+  }
+}
+
+export default function OsdfMap({
+  nodes,
+  isNodesLoading,
+  isTrafficLoading,
+  trafficError,
+}) {
+  const mapRef = useRef(null);
+  const hoveredFeatureIdRef = useRef(null);
+  const styleTunedRef = useRef(false);
+
+  const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const [selectedFeatureId, setSelectedFeatureId] = useState(null);
+  const [popupAnchor, setPopupAnchor] = useState('left');
+
+  const enrichedNodes = useMemo(() => enrichNodeTraffic(nodes), [nodes]);
+  const nodeByFeatureId = useMemo(
+    () => new Map(enrichedNodes.map((node) => [node.id, node])),
+    [enrichedNodes],
+  );
+
+  const featureCollection = useMemo(
+    () => ({
+      type: 'FeatureCollection',
+      features: enrichedNodes.map((node) => ({
+        id: node.id,
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [node.longitude, node.latitude],
+        },
+        properties: {
+          featureId: node.id,
+          nodeId: node.nodeId,
+          institution: node.institution,
+          trafficTotal: node.totalTraffic,
+          trafficNorm: node.trafficNorm,
+        },
+      })),
+    }),
+    [enrichedNodes],
+  );
+
+  useEffect(() => {
+    if (selectedFeatureId && !nodeByFeatureId.has(selectedFeatureId)) {
+      setSelectedFeatureId(null);
+    }
+  }, [selectedFeatureId, nodeByFeatureId]);
+
+  const clearFeatureHover = useCallback(() => {
+    const map = mapRef.current?.getMap();
+    const previousId = hoveredFeatureIdRef.current;
+    if (!map || previousId == null) return;
+
+    try {
+      map.setFeatureState({ source: ACTIVE_SOURCE_ID, id: previousId }, { hover: false });
+    } catch (error) {
+      // Safe no-op when feature/source is not yet available.
+    }
+
+    hoveredFeatureIdRef.current = null;
+  }, []);
+
+  const setFeatureHover = useCallback(
+    (featureId) => {
+      const map = mapRef.current?.getMap();
+      if (!map) return;
+
+      const previousId = hoveredFeatureIdRef.current;
+      if (previousId === featureId) return;
+
+      if (previousId != null) {
+        try {
+          map.setFeatureState({ source: ACTIVE_SOURCE_ID, id: previousId }, { hover: false });
+        } catch (error) {
+          // Safe no-op when feature/source is not yet available.
+        }
+      }
+
+      if (featureId != null) {
+        try {
+          map.setFeatureState({ source: ACTIVE_SOURCE_ID, id: featureId }, { hover: true });
+          hoveredFeatureIdRef.current = featureId;
+          return;
+        } catch (error) {
+          // Safe no-op when feature/source is not yet available.
+        }
+      }
+
+      hoveredFeatureIdRef.current = null;
+    },
+    [],
+  );
+
+  useEffect(() => () => clearFeatureHover(), [clearFeatureHover]);
+
+  const selectedNode = selectedFeatureId ? nodeByFeatureId.get(selectedFeatureId) : null;
+
+  const onMapLoad = useCallback((event) => {
+    setIsMapLoaded(true);
+    if (!styleTunedRef.current) {
+      softenCompetingStyleLayers(event.target);
+      styleTunedRef.current = true;
+    }
+  }, []);
+
+  const onMapClick = useCallback(
+    (event) => {
+      if (ENABLE_CLUSTERING) {
+        const clusterFeature = event.features?.find((feature) => feature.layer.id === CLUSTER_LAYER_ID);
+        if (clusterFeature) {
+          const clusterId = clusterFeature.properties?.cluster_id;
+          const map = mapRef.current?.getMap();
+          const source = map?.getSource(ACTIVE_SOURCE_ID);
+          if (
+            source &&
+            typeof source.getClusterExpansionZoom === 'function' &&
+            typeof clusterId !== 'undefined'
+          ) {
+            source.getClusterExpansionZoom(clusterId, (error, zoom) => {
+              if (error) return;
+              const [lng, lat] = clusterFeature.geometry.coordinates;
+              map.easeTo({
+                center: [lng, lat],
+                zoom: Math.min(zoom, 8),
+                duration: 450,
+              });
+            });
+          }
+          return;
+        }
+      }
+
+      const clickedFeature = event.features?.find((feature) => feature.layer.id === CORE_LAYER_ID);
+      if (!clickedFeature) {
+        setSelectedFeatureId(null);
+        return;
+      }
+
+      const featureId = clickedFeature.properties?.featureId;
+      if (typeof featureId === 'string') {
+        setSelectedFeatureId(featureId);
+
+        const canvasWidth = event.target?.getCanvas()?.clientWidth || 0;
+        const shouldFlipToLeftSide = canvasWidth > 0 && event.point.x > canvasWidth * 0.72;
+        setPopupAnchor(shouldFlipToLeftSide ? 'right' : 'left');
+      }
+    },
+    [],
+  );
+
+  const onMouseMove = useCallback(
+    (event) => {
+      const hovered = event.features?.find((feature) => feature.layer.id === CORE_LAYER_ID);
+      const hoveredId = hovered?.id ?? null;
+      setFeatureHover(hoveredId);
+
+      const canvas = mapRef.current?.getMap()?.getCanvas();
+      if (canvas) {
+        canvas.style.cursor = hovered ? 'pointer' : '';
+      }
+    },
+    [setFeatureHover],
+  );
+
+  const onMouseLeave = useCallback(() => {
+    clearFeatureHover();
+    const canvas = mapRef.current?.getMap()?.getCanvas();
+    if (canvas) {
+      canvas.style.cursor = '';
+    }
+  }, [clearFeatureHover]);
+
+  return (
+    <div className="osdf-map relative h-[600px] min-h-[600px] w-full overflow-hidden rounded-2xl border border-slate-700 bg-slate-950">
+      <MapView
+        ref={mapRef}
+        mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+        mapStyle="mapbox://styles/djw8605/cmm2idej2002r01qo03vef41r"
+        initialViewState={{
+          longitude: 8,
+          latitude: 20,
+          zoom: 1.8,
+        }}
+        style={{ width: '100%', height: '100%', minHeight: 600 }}
+        interactiveLayerIds={ENABLE_CLUSTERING ? [CORE_LAYER_ID, CLUSTER_LAYER_ID] : [CORE_LAYER_ID]}
+        onLoad={onMapLoad}
+        onClick={onMapClick}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+      >
+        <NavigationControl position="top-right" />
+        <FullscreenControl position="top-right" />
+
+        {isMapLoaded ? (
+          <Source
+            id={ACTIVE_SOURCE_ID}
+            type="geojson"
+            data={featureCollection}
+            {...(ENABLE_CLUSTERING
+              ? {
+                  cluster: true,
+                  clusterMaxZoom: CLUSTER_MAX_ZOOM,
+                  clusterRadius: CLUSTER_RADIUS,
+                }
+              : {})}
+          >
+            {ENABLE_CLUSTERING ? (
+              <>
+                <Layer {...clusterLayer} />
+                <Layer {...clusterCountLayer} />
+              </>
+            ) : null}
+            <Layer {...outerHaloLayer} />
+            <Layer {...midHaloLayer} />
+            <Layer {...coreLayer} />
+          </Source>
+        ) : null}
+
+        {selectedNode ? (
+          <Popup
+            className="osdf-popup"
+            anchor={popupAnchor}
+            closeOnClick={true}
+            maxWidth="360px"
+            longitude={Number(selectedNode.longitude)}
+            latitude={Number(selectedNode.latitude)}
+            onClose={() => setSelectedFeatureId(null)}
+            offset={18}
+          >
+            <OsdfPopup node={selectedNode} />
+          </Popup>
+        ) : null}
+      </MapView>
+
+      {isNodesLoading ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-slate-950/45 text-sm font-medium text-slate-200">
+          Loading OSDF nodes...
+        </div>
+      ) : null}
+
+      {isTrafficLoading && !isNodesLoading ? (
+        <div className="pointer-events-none absolute left-3 top-3 rounded-md border border-slate-600 bg-slate-900/90 px-3 py-1.5 text-xs text-slate-300">
+          Loading traffic overlay...
+        </div>
+      ) : null}
+
+      {trafficError ? (
+        <div className="pointer-events-none absolute right-3 top-3 rounded-md border border-amber-700/50 bg-amber-950/80 px-3 py-1.5 text-xs text-amber-200">
+          Prometheus traffic unavailable. Showing node locations only.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/osdf/OsdfPopup.js
+++ b/components/osdf/OsdfPopup.js
@@ -1,0 +1,73 @@
+import { useMemo } from 'react';
+import { AreaChart, Card } from '@tremor/react';
+import { formatNetworkRate } from './formatters';
+
+function StatRow({ label, value }) {
+  return (
+    <div className="flex items-center justify-between gap-3 text-sm">
+      <span className="text-slate-400">{label}</span>
+      <span className="font-medium text-slate-100">{value}</span>
+    </div>
+  );
+}
+
+export default function OsdfPopup({ node }) {
+  const chartData = useMemo(() => {
+    const rawPoints = Array.isArray(node?.timeseries) ? node.timeseries : [];
+    return rawPoints.map((point) => ({
+      time: new Date(point.timestamp).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+      sent: Number(point.upload) || 0,
+      received: Number(point.download) || 0,
+    }));
+  }, [node?.timeseries]);
+
+  return (
+    <Card className="w-[320px] border border-slate-700 bg-slate-900 text-slate-100 shadow-none ring-0">
+      <div className="space-y-1">
+        <div className="text-base font-semibold text-slate-100">{node.institution}</div>
+        <div className="text-xs text-slate-400">{node.nodeId}</div>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <StatRow
+          label="Status"
+          value={
+            <span className="inline-flex items-center gap-2 text-emerald-300">
+              <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />
+              Healthy
+            </span>
+          }
+        />
+        <StatRow label="Sent" value={formatNetworkRate(node.upload)} />
+        <StatRow label="Received" value={formatNetworkRate(node.download)} />
+      </div>
+
+      <div className="mt-4 border-t border-slate-700 pt-3">
+        <div className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+          Last 60 minutes
+        </div>
+        {chartData.length > 0 ? (
+          <AreaChart
+            data={chartData}
+            index="time"
+            categories={['sent', 'received']}
+            colors={['emerald', 'sky']}
+            showLegend={true}
+            showGridLines={false}
+            startEndOnly={true}
+            showYAxis={false}
+            valueFormatter={formatNetworkRate}
+            className="h-36"
+          />
+        ) : (
+          <div className="rounded-md border border-dashed border-slate-700 bg-slate-800/60 p-4 text-center text-xs text-slate-400">
+            No traffic time series available.
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/components/osdf/formatters.js
+++ b/components/osdf/formatters.js
@@ -1,0 +1,21 @@
+export function formatNetworkRate(bytesPerSecond) {
+  if (!Number.isFinite(bytesPerSecond)) return '0 bps';
+
+  const bitsPerSecond = Math.max(bytesPerSecond, 0) * 8;
+  const units = ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps'];
+  let value = bitsPerSecond;
+  let unitIndex = 0;
+
+  while (value >= 1000 && unitIndex < units.length - 1) {
+    value /= 1000;
+    unitIndex += 1;
+  }
+
+  const precision = value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+export function formatShortNumber(value) {
+  if (!Number.isFinite(value)) return '0';
+  return new Intl.NumberFormat('en-US').format(value);
+}

--- a/hooks/useOsdfTraffic.js
+++ b/hooks/useOsdfTraffic.js
@@ -1,0 +1,80 @@
+import { useEffect } from 'react';
+import useSWR from 'swr';
+
+export const OSDF_TRAFFIC_WINDOW_MINUTES = 60;
+const OSDF_TRAFFIC_REFRESH_MS = 300000;
+
+const EMPTY_TRAFFIC = {
+  perNode: {},
+  aggregate: {
+    upload: 0,
+    download: 0,
+    timeseries: [],
+  },
+};
+
+const fetcher = async (url) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch OSDF traffic: ${response.status}`);
+  }
+  return response.json();
+};
+
+export function buildOsdfTrafficKey({
+  windowMinutes = OSDF_TRAFFIC_WINDOW_MINUTES,
+  nodeIds = [],
+  enabled = true,
+} = {}) {
+  if (!enabled) return null;
+
+  const params = new URLSearchParams();
+  params.set('windowMinutes', String(windowMinutes));
+  if (Array.isArray(nodeIds) && nodeIds.length > 0) {
+    params.set('nodeIds', nodeIds.join(','));
+  }
+
+  return `/api/osdftraffic?${params.toString()}`;
+}
+
+export function useOsdfTraffic(options = {}) {
+  const key = buildOsdfTrafficKey(options);
+  const { data, error, isLoading, mutate } = useSWR(key, fetcher, {
+    refreshInterval: 0,
+    revalidateOnFocus: false,
+    keepPreviousData: true,
+    dedupingInterval: 15000,
+  });
+
+  useEffect(() => {
+    if (!key) return undefined;
+
+    const refreshTraffic = () => {
+      if (typeof document !== 'undefined' && document.hidden) return;
+      mutate();
+    };
+
+    const intervalId = setInterval(refreshTraffic, OSDF_TRAFFIC_REFRESH_MS);
+    const handleVisibilityChange = () => {
+      if (document.hidden) return;
+      mutate();
+    };
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+
+    return () => {
+      clearInterval(intervalId);
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+      }
+    };
+  }, [key, mutate]);
+
+  return {
+    traffic: data || EMPTY_TRAFFIC,
+    isLoading,
+    error,
+  };
+}

--- a/pages/api/osdftraffic.js
+++ b/pages/api/osdftraffic.js
@@ -1,0 +1,268 @@
+import { PrometheusDriver } from 'prometheus-query';
+import { getNodesDataFromR2 } from '../../lib/nodesUtils';
+
+const prom = new PrometheusDriver({
+  endpoint: 'https://prometheus.nrp-nautilus.io/',
+  baseURL: '/api/v1',
+  timeout: 60000,
+});
+
+const DEFAULT_WINDOW_MINUTES = 60;
+const MAX_WINDOW_MINUTES = 360;
+const STEP_SECONDS = 60;
+
+const EMPTY_TRAFFIC = {
+  perNode: {},
+  aggregate: {
+    upload: 0,
+    download: 0,
+    timeseries: [],
+  },
+};
+
+function normalizeSites(nodesPayload) {
+  if (Array.isArray(nodesPayload)) return nodesPayload;
+  if (nodesPayload && typeof nodesPayload === 'object') return Object.values(nodesPayload);
+  return [];
+}
+
+function normalizeNodeId(nodeId) {
+  if (typeof nodeId !== 'string') return '';
+  return nodeId.replace(/:[0-9]+$/, '');
+}
+
+function extractOsdfNodeIds(sites) {
+  const nodeIds = new Set();
+  for (const site of sites) {
+    const nodes = Array.isArray(site?.nodes) ? site.nodes : [];
+    for (const node of nodes) {
+      if (node?.cache !== true) continue;
+      if (typeof node?.name !== 'string' || node.name.length === 0) continue;
+      nodeIds.add(normalizeNodeId(node.name));
+    }
+  }
+  return Array.from(nodeIds);
+}
+
+function parseRequestedNodeIds(nodeIdsQuery) {
+  if (typeof nodeIdsQuery === 'undefined') return [];
+  const csv = Array.isArray(nodeIdsQuery) ? nodeIdsQuery.join(',') : nodeIdsQuery;
+  if (typeof csv !== 'string') return [];
+
+  const unique = new Set();
+  for (const value of csv.split(',')) {
+    const normalized = normalizeNodeId(value.trim());
+    if (normalized) unique.add(normalized);
+  }
+  return Array.from(unique);
+}
+
+function escapeRegex(value) {
+  // PromQL string literals require escaped backslashes (e.g. "\\.") so the
+  // regex engine receives the intended literal metacharacter escape ("\.")
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\\\$&');
+}
+
+function buildTrafficQuery(nodeRegex) {
+  const filter = `{instance=~"(${nodeRegex})(:[0-9]+)?",device=~"en.*|et.*"}`;
+
+  const perNodeUpload = `
+    label_replace(
+      label_replace(
+        label_replace(
+          sum by (instance) (rate(node_network_transmit_bytes_total${filter}[5m])),
+          "nodeId", "$1", "instance", "([^:]+)(:[0-9]+)?"
+        ),
+        "direction", "upload", "__name__", ".*"
+      ),
+      "scope", "perNode", "__name__", ".*"
+    )
+  `;
+
+  const perNodeDownload = `
+    label_replace(
+      label_replace(
+        label_replace(
+          sum by (instance) (rate(node_network_receive_bytes_total${filter}[5m])),
+          "nodeId", "$1", "instance", "([^:]+)(:[0-9]+)?"
+        ),
+        "direction", "download", "__name__", ".*"
+      ),
+      "scope", "perNode", "__name__", ".*"
+    )
+  `;
+
+  const aggregateUpload = `
+    label_replace(
+      label_replace(
+        sum(rate(node_network_transmit_bytes_total${filter}[5m])),
+        "direction", "upload", "__name__", ".*"
+      ),
+      "scope", "aggregate", "__name__", ".*"
+    )
+  `;
+
+  const aggregateDownload = `
+    label_replace(
+      label_replace(
+        sum(rate(node_network_receive_bytes_total${filter}[5m])),
+        "direction", "download", "__name__", ".*"
+      ),
+      "scope", "aggregate", "__name__", ".*"
+    )
+  `;
+
+  return `(${perNodeUpload}) or (${perNodeDownload}) or (${aggregateUpload}) or (${aggregateDownload})`;
+}
+
+function parseSeriesValues(values) {
+  if (!Array.isArray(values)) return [];
+  const parsed = values
+    .map((point) => {
+      const timestamp = new Date(point?.time).getTime();
+      const value = Number(point?.value);
+      if (!Number.isFinite(timestamp) || !Number.isFinite(value)) return null;
+      return { timestamp, value };
+    })
+    .filter(Boolean);
+
+  parsed.sort((a, b) => a.timestamp - b.timestamp);
+  return parsed;
+}
+
+function mergeDirectionalSeries(uploadSeries, downloadSeries) {
+  const bucket = new Map();
+
+  for (const point of uploadSeries) {
+    bucket.set(point.timestamp, {
+      timestamp: point.timestamp,
+      upload: point.value,
+      download: 0,
+    });
+  }
+
+  for (const point of downloadSeries) {
+    const row = bucket.get(point.timestamp) || {
+      timestamp: point.timestamp,
+      upload: 0,
+      download: 0,
+    };
+    row.download = point.value;
+    bucket.set(point.timestamp, row);
+  }
+
+  return Array.from(bucket.values())
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .map((row) => ({
+      ...row,
+      total: row.upload + row.download,
+    }));
+}
+
+export default async function handler(req, res) {
+  const rawWindow = Number.parseInt(req.query.windowMinutes, 10);
+  const windowMinutes = Number.isFinite(rawWindow)
+    ? Math.min(Math.max(rawWindow, 5), MAX_WINDOW_MINUTES)
+    : DEFAULT_WINDOW_MINUTES;
+
+  try {
+    const requestedNodeIds = parseRequestedNodeIds(req.query.nodeIds);
+    const hasRequestedNodeIds = typeof req.query.nodeIds !== 'undefined';
+    const osdfNodeIds = hasRequestedNodeIds
+      ? requestedNodeIds
+      : extractOsdfNodeIds(normalizeSites(await getNodesDataFromR2()));
+
+    if (osdfNodeIds.length === 0) {
+      res.setHeader('Cache-Control', 's-maxage=120, stale-while-revalidate');
+      res.setHeader('Content-Type', 'application/json');
+      res.status(200).json(EMPTY_TRAFFIC);
+      return;
+    }
+
+    const nodeRegex = osdfNodeIds.map(escapeRegex).join('|');
+    const query = buildTrafficQuery(nodeRegex);
+    const end = new Date();
+    const start = new Date(end.getTime() - windowMinutes * 60 * 1000);
+    const queryResult = await prom.rangeQuery(query, start, end, STEP_SECONDS);
+
+    const traffic = {
+      perNode: {},
+      aggregate: {
+        upload: 0,
+        download: 0,
+        timeseries: [],
+      },
+    };
+
+    // Initialize all known OSDF nodes so map rendering can proceed even if Prometheus omits a series.
+    for (const nodeId of osdfNodeIds) {
+      traffic.perNode[nodeId] = {
+        upload: 0,
+        download: 0,
+        timeseries: [],
+      };
+    }
+
+    for (const series of queryResult?.result || []) {
+      const labels = series?.metric?.labels || {};
+      const direction = labels.direction;
+      if (direction !== 'upload' && direction !== 'download') continue;
+
+      const seriesValues = parseSeriesValues(series.values);
+      const latestValue = seriesValues.length > 0 ? seriesValues[seriesValues.length - 1].value : 0;
+
+      if (labels.scope === 'aggregate' || !labels.nodeId) {
+        traffic.aggregate[direction] = latestValue;
+        if (direction === 'upload') {
+          traffic.aggregate._uploadSeries = seriesValues;
+        } else {
+          traffic.aggregate._downloadSeries = seriesValues;
+        }
+        continue;
+      }
+
+      const nodeId = normalizeNodeId(labels.nodeId);
+      if (!nodeId) continue;
+
+      if (!traffic.perNode[nodeId]) {
+        traffic.perNode[nodeId] = {
+          upload: 0,
+          download: 0,
+          timeseries: [],
+        };
+      }
+
+      traffic.perNode[nodeId][direction] = latestValue;
+
+      if (direction === 'upload') {
+        traffic.perNode[nodeId]._uploadSeries = seriesValues;
+      } else {
+        traffic.perNode[nodeId]._downloadSeries = seriesValues;
+      }
+    }
+
+    for (const nodeId of Object.keys(traffic.perNode)) {
+      const uploadSeries = traffic.perNode[nodeId]._uploadSeries || [];
+      const downloadSeries = traffic.perNode[nodeId]._downloadSeries || [];
+      traffic.perNode[nodeId].timeseries = mergeDirectionalSeries(uploadSeries, downloadSeries);
+      delete traffic.perNode[nodeId]._uploadSeries;
+      delete traffic.perNode[nodeId]._downloadSeries;
+    }
+
+    const aggregateUploadSeries = traffic.aggregate._uploadSeries || [];
+    const aggregateDownloadSeries = traffic.aggregate._downloadSeries || [];
+    traffic.aggregate.timeseries = mergeDirectionalSeries(aggregateUploadSeries, aggregateDownloadSeries);
+    delete traffic.aggregate._uploadSeries;
+    delete traffic.aggregate._downloadSeries;
+
+    res.setHeader('Cache-Control', 's-maxage=120, stale-while-revalidate');
+    res.setHeader('Content-Type', 'application/json');
+    res.status(200).json(traffic);
+  } catch (error) {
+    console.error('Error in osdftraffic API:', error);
+    res.status(500).json({
+      error: 'Failed to fetch OSDF traffic',
+      ...EMPTY_TRAFFIC,
+    });
+  }
+}

--- a/pages/osdf-nodes.js
+++ b/pages/osdf-nodes.js
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import useSWR from 'swr';
+import OsdfKpis from '../components/osdf/OsdfKpis';
+import { OSDF_TRAFFIC_WINDOW_MINUTES, useOsdfTraffic } from '../hooks/useOsdfTraffic';
+
+const OsdfMap = dynamic(() => import('../components/osdf/OsdfMap'), {
+  ssr: false,
+  loading: () => (
+    <div className="min-h-[600px] w-full animate-pulse rounded-2xl border border-slate-700 bg-slate-800/50" />
+  ),
+});
+
+const fetcher = async (url) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+  return response.json();
+};
+
+function normalizeSites(nodesPayload) {
+  if (Array.isArray(nodesPayload)) return nodesPayload;
+  if (nodesPayload && typeof nodesPayload === 'object') return Object.values(nodesPayload);
+  return [];
+}
+
+function extractOsdfNodes(sites) {
+  const osdfNodes = [];
+
+  for (const site of sites) {
+    const latitude = Number(site?.latitude);
+    const longitude = Number(site?.longitude);
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) continue;
+
+    const siteNodes = Array.isArray(site?.nodes) ? site.nodes : [];
+    for (const node of siteNodes) {
+      if (node?.cache !== true) continue;
+      if (typeof node?.name !== 'string' || node.name.length === 0) continue;
+
+      const slug = site?.slug || site?.id || site?.name || 'site';
+      osdfNodes.push({
+        id: `${slug}::${node.name}`,
+        nodeId: node.name,
+        institution: site?.name || site?.siteName || 'Unknown institution',
+        latitude,
+        longitude,
+      });
+    }
+  }
+
+  return osdfNodes;
+}
+
+function attachTraffic(nodes, perNodeTraffic) {
+  return nodes.map((node) => {
+    const direct = perNodeTraffic[node.nodeId];
+    const normalized = perNodeTraffic[node.nodeId.replace(/:[0-9]+$/, '')];
+    const traffic = direct || normalized || {};
+
+    return {
+      ...node,
+      upload: Number(traffic.upload) || 0,
+      download: Number(traffic.download) || 0,
+      timeseries: Array.isArray(traffic.timeseries) ? traffic.timeseries : [],
+    };
+  });
+}
+
+export default function OsdfNodesPage() {
+  const {
+    data: nodesPayload,
+    error: nodesError,
+    isLoading: isNodesLoading,
+  } = useSWR('/api/nodes', fetcher, {
+    revalidateOnFocus: false,
+    keepPreviousData: true,
+  });
+
+  const osdfNodes = useMemo(() => extractOsdfNodes(normalizeSites(nodesPayload)), [nodesPayload]);
+  const osdfNodeIds = useMemo(() => osdfNodes.map((node) => node.nodeId), [osdfNodes]);
+  const { traffic, isLoading: isTrafficLoading, error: trafficError } = useOsdfTraffic({
+    windowMinutes: OSDF_TRAFFIC_WINDOW_MINUTES,
+    nodeIds: osdfNodeIds,
+    enabled: !isNodesLoading,
+  });
+
+  const mappedNodes = useMemo(() => attachTraffic(osdfNodes, traffic.perNode || {}), [osdfNodes, traffic.perNode]);
+
+  return (
+    <>
+      <Head>
+        <title>OSDF nodes</title>
+      </Head>
+
+      <main className="min-h-screen bg-slate-900 text-slate-100">
+        <div className="w-full px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-semibold tracking-tight text-slate-100">OSDF nodes</h1>
+
+          <div className="mt-5">
+            <OsdfKpis
+              totalNodes={osdfNodes.length}
+              aggregateTraffic={traffic.aggregate || { upload: 0, download: 0, timeseries: [] }}
+              isLoading={isNodesLoading || isTrafficLoading}
+            />
+          </div>
+
+          {nodesError ? (
+            <div className="mt-4 rounded-lg border border-red-800/60 bg-red-950/60 px-4 py-3 text-sm text-red-200">
+              Failed to load node locations from <code>/api/nodes</code>.
+            </div>
+          ) : null}
+
+          <div className="mt-6">
+            <OsdfMap
+              nodes={mappedNodes}
+              isNodesLoading={isNodesLoading}
+              isTrafficLoading={isTrafficLoading}
+              trafficError={trafficError}
+            />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -139,3 +139,115 @@ thead {
   }
 }
 
+/* OSDF map popup dark theme + micro animation */
+.osdf-popup .mapboxgl-popup-content {
+  background: #0f172a;
+  color: #e2e8f0;
+  border: 1px solid #475569;
+  border-radius: 0.85rem;
+  padding: 0;
+  box-shadow: 0 18px 34px rgba(2, 6, 23, 0.58);
+  animation: osdfPopupIn 130ms cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: center;
+}
+
+.osdf-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-content {
+  transform-origin: left center;
+}
+
+.osdf-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-content {
+  transform-origin: right center;
+}
+
+.osdf-popup .mapboxgl-popup-close-button {
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 9999px;
+  border: 1px solid #475569;
+  background: #1e293b;
+  color: #cbd5e1;
+  font-size: 15px;
+  line-height: 24px;
+  text-align: center;
+  transition: all 120ms ease;
+}
+
+.osdf-popup .mapboxgl-popup-close-button:hover {
+  background: #334155;
+  color: #f8fafc;
+  border-color: #64748b;
+}
+
+.osdf-popup.mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
+.osdf-popup.mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip,
+.osdf-popup.mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
+  border-bottom-color: #0f172a;
+}
+
+.osdf-popup.mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
+.osdf-popup.mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip,
+.osdf-popup.mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
+  border-top-color: #0f172a;
+}
+
+.osdf-popup.mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
+  border-right-color: #0f172a;
+}
+
+.osdf-popup.mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
+  border-left-color: #0f172a;
+}
+
+@keyframes osdfPopupIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Dark-styled map controls */
+.osdf-map .mapboxgl-ctrl-top-right {
+  top: 0.75rem;
+  right: 0.75rem;
+}
+
+.osdf-map .mapboxgl-ctrl-group {
+  overflow: hidden;
+  border-radius: 0.75rem;
+  border: 1px solid #334155;
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 8px 20px rgba(2, 6, 23, 0.4);
+}
+
+.osdf-map .mapboxgl-ctrl-group button {
+  width: 34px;
+  height: 34px;
+  background: transparent;
+}
+
+.osdf-map .mapboxgl-ctrl-group button + button {
+  border-top: 1px solid #334155;
+}
+
+.osdf-map .mapboxgl-ctrl-group button:hover {
+  background: #1e293b;
+}
+
+.osdf-map .mapboxgl-ctrl-icon {
+  filter: brightness(0) invert(1) opacity(0.86);
+}
+
+/* Slight visual distinction for KPI trend fills */
+.kpi-trend-sent .recharts-area-area {
+  opacity: 0.34;
+}
+
+.kpi-trend-received .recharts-area-area {
+  opacity: 0.26;
+}


### PR DESCRIPTION
- Add OsdfMap component for rendering a map with OSDF nodes and traffic data.
- Create OsdfPopup component for displaying node details in a popup.
- Implement traffic data fetching with useOsdfTraffic hook and API endpoint.
- Introduce formatters for network rate and number formatting.
- Create a new page for OSDF nodes, integrating map and KPI components.
- Enhance global styles for dark theme and map controls.